### PR TITLE
Always --pull during docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ build: bin/$(ARCH)/$(BIN)
 
 bin/$(ARCH)/$(BIN): build-dirs
 	@echo "building: $@"
+	@docker pull $(BUILD_IMAGE)
 	@docker run                                                            \
 	    -ti                                                                \
 	    -u $$(id -u):$$(id -g)                                             \
@@ -106,7 +107,7 @@ container: .container-$(DOTFILE_IMAGE) container-name
 	    -e 's|ARG_ARCH|$(ARCH)|g' \
 	    -e 's|ARG_FROM|$(BASEIMAGE)|g' \
 	    Dockerfile.in > .dockerfile-$(ARCH)
-	@docker build -t $(IMAGE):$(VERSION) -f .dockerfile-$(ARCH) .
+	@docker build --pull -t $(IMAGE):$(VERSION) -f .dockerfile-$(ARCH) .
 	@docker images -q $(IMAGE):$(VERSION) > $@
 
 container-name:


### PR DESCRIPTION
Without --pull, it's possible to use old base images which may have fixed vulnerabilities upstream.

x-ref kubernetes/kubernetes#47386

After merging this, we should probably create a new tag and then rebuild the image.