### PR TITLE
use capabilities instead of privileged

### DIFF
--- a/ip-masq-agent.yaml
+++ b/ip-masq-agent.yaml
@@ -14,7 +14,9 @@ spec:
       - name: ip-masq-agent
         image: gcr.io/google-containers/ip-masq-agent-amd64:v2.0.0
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            add: ["NET_ADMIN", "NET_RAW"]
         volumeMounts:
           - name: config
             mountPath: /etc/config


### PR DESCRIPTION
fixes #28 

I looked around and as far as i can tell you need `CAP_NET_ADMIN` and `CAP_NET_RAW` to manage iptables. This works in https://github.com/kubernetes-sigs/kind/pull/500