### PR TITLE
just use ParseCIDR to validate CIDRs instead of regex

### DIFF
--- a/cmd/ip-masq-agent/ip-masq-agent.go
+++ b/cmd/ip-masq-agent/ip-masq-agent.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -221,17 +220,10 @@ func (c *MasqConfig) validate() error {
 	return nil
 }
 
-const cidrRE = `^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,2}$`
-const cidrMatchErrFmt = "CIDR %q did not match %q (for example, '10.0.0.0/8' is correct CIDR notation)"
 const cidrParseErrFmt = "CIDR %q could not be parsed, %v"
 const cidrAlignErrFmt = "CIDR %q is not aligned to a CIDR block, ip: %q network: %q"
 
 func validateCIDR(cidr string) error {
-	// regex test
-	re := regexp.MustCompile(cidrRE)
-	if !re.MatchString(cidr) {
-		return fmt.Errorf(cidrMatchErrFmt, cidr, cidrRE)
-	}
 	// parse test
 	ip, ipnet, err := net.ParseCIDR(cidr)
 	if err != nil {

--- a/cmd/ip-masq-agent/ip-masq-agent_test.go
+++ b/cmd/ip-masq-agent/ip-masq-agent_test.go
@@ -85,11 +85,11 @@ var validateConfigTests = []struct {
 	// Default Config
 	{NewMasqConfigNoReservedRanges(), nil},
 	// CIDR that doesn't match regex
-	{&MasqConfig{NonMasqueradeCIDRs: []string{"abcdefg"}}, fmt.Errorf(cidrMatchErrFmt, "abcdefg", cidrRE)},
+	{&MasqConfig{NonMasqueradeCIDRs: []string{"abcdefg"}}, fmt.Errorf(cidrParseErrFmt, "abcdefg", fmt.Errorf("invalid CIDR address: %s", "abcdefg"))},
 	// Multiple CIDRs, one doesn't match regex
-	{&MasqConfig{NonMasqueradeCIDRs: []string{"10.0.0.0/8", "abcdefg"}}, fmt.Errorf(cidrMatchErrFmt, "abcdefg", cidrRE)},
+	{&MasqConfig{NonMasqueradeCIDRs: []string{"10.0.0.0/8", "abcdefg"}}, fmt.Errorf(cidrParseErrFmt, "abcdefg", fmt.Errorf("invalid CIDR address: %s", "abcdefg"))},
 	// CIDR that matches regex but can't be parsed
-	{&MasqConfig{NonMasqueradeCIDRs: []string{"10.256.0.0/16"}}, fmt.Errorf(cidrParseErrFmt, "10.256.0.0/16", fmt.Errorf("invalid CIDR address: 10.256.0.0/16"))},
+	{&MasqConfig{NonMasqueradeCIDRs: []string{"10.256.0.0/16"}}, fmt.Errorf(cidrParseErrFmt, "10.256.0.0/16", fmt.Errorf("invalid CIDR address: %s", "10.256.0.0/16"))},
 	// Misaligned CIDR
 	{&MasqConfig{NonMasqueradeCIDRs: []string{"10.0.0.1/8"}}, fmt.Errorf(cidrAlignErrFmt, "10.0.0.1/8", "10.0.0.1", "10.0.0.0/8")},
 }


### PR DESCRIPTION
`net.ParseCIDR` already validates correctly and handles IPv6

/cc @MrHohn 