### PR TITLE
Add 198.51.100.0/24 to default non-masq IP ranges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The agent accepts two flags, which may be specified in the yaml file.
 :  The name of the `iptables` chain to use. By default set to `IP-MASQ-AGENT`
 
 `nomasq-all-reserved-ranges`
-:  Whether or not to masquerade all RFC reserved ranges when the configmap is empty. The default is `false`. When `false`, the agent will masquerade to every destination except the ranges reserved by RFC 1918 (namely `10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16`). When `true`, the agent will masquerade to every destination that is not marked reserved by an RFC. The full list of ranges is (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `192.0.0.0/24`, `192.0.2.0/24`, `192.88.99.0/24`, `198.18.0.0/15`, `203.0.113.0/24`, and `240.0.0.0/4`). Note however, that this list of ranges is overridden by specifying the nonMasqueradeCIDRs key in the agent configmap.
+:  Whether or not to masquerade all RFC reserved ranges when the configmap is empty. The default is `false`. When `false`, the agent will masquerade to every destination except the ranges reserved by RFC 1918 (namely `10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16`). When `true`, the agent will masquerade to every destination that is not marked reserved by an RFC. The full list of ranges is (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `192.0.0.0/24`, `192.0.2.0/24`, `192.88.99.0/24`, `198.18.0.0/15`, `198.51.100.0/24`, `203.0.113.0/24`, and `240.0.0.0/4`). Note however, that this list of ranges is overridden by specifying the nonMasqueradeCIDRs key in the agent configmap.
 
 
 ## Rationale

--- a/cmd/ip-masq-agent/ip-masq-agent.go
+++ b/cmd/ip-masq-agent/ip-masq-agent.go
@@ -81,13 +81,14 @@ func NewMasqConfig(masqAllReservedRanges bool) *MasqConfig {
 
 	if masqAllReservedRanges {
 		nonMasq = append(nonMasq,
-			"100.64.0.0/10",  // RFC 6598
-			"192.0.0.0/24",   // RFC 6890
-			"192.0.2.0/24",   // RFC 5737
-			"192.88.99.0/24", // RFC 7526
-			"198.18.0.0/15",  // RFC 2544
-			"203.0.113.0/24", // RFC 5737
-			"240.0.0.0/4")    // Former Class E range obsoleted by RFC 3232
+			"100.64.0.0/10",   // RFC 6598
+			"192.0.0.0/24",    // RFC 6890
+			"192.0.2.0/24",    // RFC 5737
+			"192.88.99.0/24",  // RFC 7526
+			"198.18.0.0/15",   // RFC 2544
+			"198.51.100.0/24", // RFC 5737
+			"203.0.113.0/24",  // RFC 5737
+			"240.0.0.0/4")     // Former Class E range obsoleted by RFC 3232
 	}
 
 	return &MasqConfig{

--- a/cmd/ip-masq-agent/ip-masq-agent_test.go
+++ b/cmd/ip-masq-agent/ip-masq-agent_test.go
@@ -68,6 +68,7 @@ func NewMasqConfigWithReservedRanges() *MasqConfig {
 			"192.0.2.0/24",
 			"192.88.99.0/24",
 			"198.18.0.0/15",
+			"198.51.100.0/24",
 			"203.0.113.0/24",
 			"240.0.0.0/4"},
 		MasqLinkLocal:  false,
@@ -257,6 +258,7 @@ COMMIT
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 192.0.2.0/24 -j RETURN
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 192.88.99.0/24 -j RETURN
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 198.18.0.0/15 -j RETURN
+-A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 198.51.100.0/24 -j RETURN
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 203.0.113.0/24 -j RETURN
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 240.0.0.0/4 -j RETURN
 -A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE


### PR DESCRIPTION
This adds the missing 198.51.100.0/24 as a complement of https://github.com/kubernetes-incubator/ip-masq-agent/pull/33.

/assign @MrHohn 