### PR TITLE
Push to k8s staging registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BIN := ip-masq-agent
 PKG := k8s.io/ip-masq-agent
 
 # Where to push the docker image.
-REGISTRY ?= gcr.io/google-containers
+REGISTRY ?= staging-k8s.gcr.io
 
 # Which architecture to build - see $(ALL_ARCH) for options.
 ARCH ?= amd64


### PR DESCRIPTION
The makefile currently points to `gcr.io/google-container`, which is incorrect as we need to push to staging registry first.